### PR TITLE
Synchronous stop

### DIFF
--- a/lib/riddle/controller.rb
+++ b/lib/riddle/controller.rb
@@ -46,9 +46,13 @@ module Riddle
     
     def stop
       return true unless running?
-      Process.kill('SIGTERM', pid.to_i)
-    rescue Errno::EINVAL
-      Process.kill('SIGKILL', pid.to_i)
+      cmd = %(#{searchd} --pidfile --config "#{@path}" --stopwait)
+      
+      if RUBY_PLATFORM =~ /mswin/
+        system("start /B #{cmd} 1> NUL 2>&1")
+      else
+        `#{cmd}`
+      end
     ensure
       return !running?
     end


### PR DESCRIPTION
Use the `searchd` command `--stopwait` to synchronously terminate the `searchd` process.
