### PR TITLE
Fix ruby.1.8.6 with backport

### DIFF
--- a/lib/riddle.rb
+++ b/lib/riddle.rb
@@ -48,6 +48,7 @@ require 'riddle/auto_version'
 require 'riddle/client'
 require 'riddle/configuration'
 require 'riddle/controller'
+require 'riddle/ruby_backports'
 
 Riddle.loaded_version = nil
 Riddle::AutoVersion.configure

--- a/lib/riddle/ruby_backports.rb
+++ b/lib/riddle/ruby_backports.rb
@@ -1,0 +1,22 @@
+module Riddle
+  module RubyBackports
+    module ArrayShuffle
+      # Standard in Ruby 1.8.7+. See official documentation[http://ruby-doc.org/core-1.9/classes/Array.html]
+      def shuffle
+        dup.shuffle!
+      end unless method_defined? :shuffle
+
+      # Standard in Ruby 1.8.7+. See official documentation[http://ruby-doc.org/core-1.9/classes/Array.html]
+      def shuffle!
+        size.times do |i|
+          r = i + Kernel.rand(size - i)
+          self[i], self[r] = self[r], self[i]
+        end
+        self
+      end unless method_defined? :shuffle!
+    end
+  end
+end
+
+Array.send(:include, Riddle::RubyBackports::ArrayShuffle)
+


### PR DESCRIPTION
Hi Pat,

In this pull request I've resolved the problem with ruby 1.8.6 and the shuffle method using backports:

https://github.com/blackwinter/ruby-backports
