### PR TITLE
Fix Riddle infinite loop issue

### DIFF
--- a/lib/riddle/client.rb
+++ b/lib/riddle/client.rb
@@ -637,6 +637,10 @@ module Riddle
         
         while response.length < (length || 0)
           part = socket.recv(length - response.length)
+
+          # will return 0 bytes if remote side closed TCP connection, e.g, searchd segfaulted.
+          break if part.length == 0 && socket.is_a?(TcpSocket)
+
           response << part if part
         end
       end


### PR DESCRIPTION
Gracefully handle race condition where searchd segfaults or is killed after returning header bytes, but prior to returning full response body. Without this fix, Riddle hangs in an infinite loop trying to read from a closed socket.
