### PR TITLE
support coreseek(sphinx)

### DIFF
--- a/lib/riddle/controller.rb
+++ b/lib/riddle/controller.rb
@@ -12,7 +12,7 @@ module Riddle
     end
     
     def sphinx_version
-      `#{indexer} 2>&1`[/^Sphinx (\d+\.\d+(\.\d+|(?:-dev|(\-id64)?\-beta)))/, 1]
+      `#{indexer} 2>&1`[/Sphinx (\d+\.\d+(\.\d+|(?:-dev|(\-id64)?\-beta)))/, 1]
     rescue
       nil
     end


### PR DESCRIPTION
CoreSeek is the full-text search engine that support chinese, it was base on sphinx.
If we run the inderer command in coreseek, we will get the result:  

```
Coreseek Fulltext 3.2 [ Sphinx 0.9.9-release (r2117)]
```

As we can see, the version information isn't start with Sphinx, so riddle can not get the version of sphinx.

I make a little change, just remove the ^ regexp symbol, and I think the change will not break the rspec test, I wish you guys can merge it.

Thanks.
