### PR TITLE
Avoid checking availability of Encoding#force_encoding for each Riddle::Response

### DIFF
--- a/lib/riddle/client.rb
+++ b/lib/riddle/client.rb
@@ -617,9 +617,7 @@ module Riddle
       length   = 0
       message  = Array(messages).join("")
       
-      if message.respond_to?(:force_encoding)
-        message = message.force_encoding('ASCII-8BIT')
-      end
+      message = Response.encoding_proc(message, 'ASCII-8BIT')
       
       connect do |socket|
         case command

--- a/lib/riddle/client/message.rb
+++ b/lib/riddle/client/message.rb
@@ -15,8 +15,7 @@ module Riddle
       
       # Append a string's length, then the string itself
       def append_string(str)
-        string = str.respond_to?(:force_encoding) ?
-          str.dup.force_encoding('ASCII-8BIT') : str
+        string = Response.encoding_proc.call(str.dup, 'ASCII-8BIT')
         
         @message << [string.send(@size_method)].pack('N') + string
       end

--- a/lib/riddle/client/response.rb
+++ b/lib/riddle/client/response.rb
@@ -18,7 +18,7 @@ module Riddle
         result = @str[@marker, len]
         @marker += len
         
-        Response.encoding_proc.call result # use call instead of yield for 1.8 compatibility
+        Response.encoding_proc.call(result, ::Encoding.default_external) # use call instead of yield for 1.8 compatibility
       end
       
       # Return the next integer value from the stream
@@ -94,9 +94,9 @@ module Riddle
       # Use default encoding if available (1.9)
       def self.encoding_proc
         @@encoding_proc ||= if (defined?(::Encoding) && ::Encoding.respond_to?(:default_external))
-                              lambda{|s| s.force_encoding(::Encoding.default_external) }
+                              lambda{|s,e| s.force_encoding(e) }
                             else
-                              lambda{|s| s }
+                              lambda{|s,e| s }
                             end
       end
     end


### PR DESCRIPTION
Encoding is being looked up for each new Response. I'm caching how to handle the result so it only happens once. I ran the response_spec in 1.9.2p180 and ree-1.8.7-2010.02
