### PR TITLE
defined? ::Encoding was missed in self.encode method

### DIFF
--- a/lib/riddle.rb
+++ b/lib/riddle.rb
@@ -12,7 +12,7 @@ module Riddle #:nodoc:
     #
   end
 
-  def self.encode(data, encoding = ::Encoding.default_external)
+  def self.encode(data, encoding = defined?(::Encoding) && ::Encoding.default_external)
     if @@use_encoding
       data.force_encoding(encoding)
     else


### PR DESCRIPTION
Added one more check for existence of the Encoding class for compatibility with ruby 1.8
