### PR TITLE
:with=>{:float_col=>1.23} now works

### DIFF
--- a/lib/riddle/client/filter.rb
+++ b/lib/riddle/client/filter.rb
@@ -30,7 +30,7 @@ module Riddle
         when Array
           if self.values.first.is_a? Float
             message.append_int FilterTypes[:float_range]
-            message.append_floats self.values.first, self.values.first
+            message.append_floats self.values.min, self.values.max
           else
             message.append_int FilterTypes[:values]
             message.append_int self.values.length


### PR DESCRIPTION
There's a bug with this version (1.5.1 and prev) of riddle where if you try to:

Model.search :with=>{:float_col=>1.23}

It returns an empty set. This fixes it.

You'll see the fix seems to be a big hacky (using FLOAT_RANGE), if you can suggest a better way to do it I'll gladly change it.
