### PR TITLE
Failover not working

### DIFF
--- a/lib/riddle/0.9.9/client.rb
+++ b/lib/riddle/0.9.9/client.rb
@@ -4,8 +4,8 @@ Riddle::Client::Versions[:update] = 0x102
 class Riddle::Client
   private
 
-  def initialise_connection
-    socket = initialise_socket
+  def initialise_connection(available_server)
+    socket = initialise_socket(available_server)
 
     # Send version
     socket.send [1].pack('N'), 0


### PR DESCRIPTION
As of 40c96fde359821a5ea57c12fc8b70d6f44922fa8, failover no longer work.

`initialise_socket` uses `server` which pulls from `@servers.first` which will not change because `servers.dup` is happening.
