### PR TITLE
Escape curly brace in gsub regexp for #each_with_prefix

### DIFF
--- a/lib/riddle/configuration/parser.rb
+++ b/lib/riddle/configuration/parser.rb
@@ -59,7 +59,7 @@ class Riddle::Configuration::Parser
 
   def each_with_prefix(prefix)
     inner.keys.select { |key| key[/^#{prefix}\s+/] }.each do |key|
-      yield key.gsub(/^#{prefix}\s+/, '').gsub(/\s*{$/, ''), inner[key]
+      yield key.gsub(/^#{prefix}\s+/, '').gsub(/\s*\{$/, ''), inner[key]
     end
   end
 


### PR DESCRIPTION
I am seeing regex warnings on STDERR with riddle 1.5.4 and it looks like the intent here was to match on lines ending with '{'.
