### PR TITLE
Riddle.encode was failing due to ::Encoding.default_external not defined

### DIFF
--- a/lib/riddle.rb
+++ b/lib/riddle.rb
@@ -12,7 +12,7 @@ module Riddle #:nodoc:
     #
   end
 
-  def self.encode(data, encoding = defined?(::Encoding) && ::Encoding.default_external)
+  def self.encode(data, encoding = @@use_encoding && ::Encoding.default_external)
     if @@use_encoding
       data.force_encoding(encoding)
     else


### PR DESCRIPTION
Swapped the encoding check to use the local @@use_encoding var before calling default_external. The class was defined, but not the method.

This issue was found using ruby 1.8.7p371 & rails 2.3.16.

Thanks for the gem!
