### PR TITLE
Within Group order should be before normal order.

### DIFF
--- a/lib/riddle/query/select.rb
+++ b/lib/riddle/query/select.rb
@@ -84,10 +84,10 @@ class Riddle::Query::Select
     sql = "SELECT #{ @values.join(', ') } FROM #{ @indices.join(', ') }"
     sql << " WHERE #{ combined_wheres }" if wheres?
     sql << " GROUP BY #{@group_by}"      if !@group_by.nil?
-    sql << " ORDER BY #{@order_by}"      if !@order_by.nil?
     unless @order_within_group_by.nil?
       sql << " WITHIN GROUP ORDER BY #{@order_within_group_by}"
     end
+    sql << " ORDER BY #{@order_by}"      if !@order_by.nil?
     sql << " #{limit_clause}"   unless @limit.nil? && @offset.nil?
     sql << " #{options_clause}" unless @options.empty?
 


### PR DESCRIPTION
Working Example: 

```
SELECT *  FROM `title_core`, `title_delta`  WHERE MATCH('@sphinx_internal_class_name (Title)') AND 
sphinx_deleted = 0  GROUP BY movie_id  WITHIN GROUP ORDER BY @weight DESC ORDER BY 
@weight DESC LIMIT 0, 20;
```

Not Working example:

```
SELECT *  FROM `title_core`, `title_delta`  WHERE MATCH('@sphinx_internal_class_name (Title)') AND
sphinx_deleted = 0  GROUP BY movie_id  ORDER BY @weight DESC WITHIN GROUP ORDER BY 
```

   @weight DESC LIMIT 0, 20;

Tested on sphinx 2.0.6
