### PR TITLE
Avoid modifying Query#snippets parameters

### DIFF
--- a/lib/riddle/query.rb
+++ b/lib/riddle/query.rb
@@ -58,8 +58,8 @@ module Riddle::Query
   end
 
   def self.snippets(data, index, query, options = nil)
-    data.gsub!("'")  { |x| "\\'" }
-    query.gsub!("'") { |x| "\\'" }
+    data = data.gsub("'")  { |x| "\\'" }
+    query = query.gsub("'") { |x| "\\'" }
 
     options = ', ' + options.keys.collect { |key|
       value = options[key]


### PR DESCRIPTION
Just a simple change/fix.

We run into problems when trying to use Thinking Sphinx's excerpts on models that have single quotation marks `'` on their fields.

This is a simple snippet that breaks (same thing happens using `ThinkingSphinx::Panes::ExcerptsPane` on ActiveRecord models):

``` ruby
text = "this doesn't work"
ex = ThinkingSphinx::Excerpter.new('some_index', 'work')
ex.excerpt!(text) # => "this doesn't <span class=\"match\">work</span>"
text              # => "this doesn\\'t work"
ex.excerpt!(text) # raises Mysql2::Error: sphinxql: syntax error, unexpected IDENT
```

The first call to `Excerpter.excerpt!` succeeds but it modifies the `text` string, so the second call fails with an ugly SphinxQL syntax error.

This fix just changes `String#gsub!` with `gsub` on `Riddle::Query#snippets` so that doesn't happen any more. Please note that i didn't test this specific change, i just modified the file from GitHub, so running the specs is more than advised :sweat_smile: . But i added a monkey patch fix that does basically the same thing in our Rails application, so i'm pretty sure it works.
