### PR TITLE
Escape column names in WHERE clauses and INSERT queries with backticks

### DIFF
--- a/lib/riddle/query/insert.rb
+++ b/lib/riddle/query/insert.rb
@@ -14,7 +14,7 @@ class Riddle::Query::Insert
   end
 
   def to_sql
-    "#{command} INTO #{@index} (#{columns_to_s}) VALUES (#{values_to_s})"
+    "#{command} INTO #{@index} (`#{columns_to_s}`) VALUES (#{values_to_s})"
   end
 
   private
@@ -24,7 +24,7 @@ class Riddle::Query::Insert
   end
 
   def columns_to_s
-    columns.join(', ')
+    columns.join('`, `')
   end
 
   def values_to_s

--- a/lib/riddle/query/select.rb
+++ b/lib/riddle/query/select.rb
@@ -134,22 +134,22 @@ class Riddle::Query::Select
   def filter_comparison_and_value(attribute, value)
     case value
     when Array
-      "#{attribute} IN (#{value.collect { |val| filter_value(val) }.join(', ')})"
+      "#{escape_column(attribute)} IN (#{value.collect { |val| filter_value(val) }.join(', ')})"
     when Range
-      "#{attribute} BETWEEN #{filter_value(value.first)} AND #{filter_value(value.last)}"
+      "#{escape_column(attribute)} BETWEEN #{filter_value(value.first)} AND #{filter_value(value.last)}"
     else
-      "#{attribute} = #{filter_value(value)}"
+      "#{escape_column(attribute)} = #{filter_value(value)}"
     end
   end
 
   def exclusive_filter_comparison_and_value(attribute, value)
     case value
     when Array
-      "#{attribute} NOT IN (#{value.collect { |val| filter_value(val) }.join(', ')})"
+      "#{escape_column(attribute)} NOT IN (#{value.collect { |val| filter_value(val) }.join(', ')})"
     when Range
-      "#{attribute} < #{filter_value(value.first)} OR #{attribute} > #{filter_value(value.last)}"
+      "#{escape_column(attribute)} < #{filter_value(value.first)} OR #{attribute} > #{filter_value(value.last)}"
     else
-      "#{attribute} <> #{filter_value(value)}"
+      "#{escape_column(attribute)} <> #{filter_value(value)}"
     end
   end
 
@@ -187,5 +187,9 @@ class Riddle::Query::Select
     else
       value
     end
+  end
+
+  def escape_column(column)
+    "`#{column}`"
   end
 end

--- a/spec/riddle/query/insert_spec.rb
+++ b/spec/riddle/query/insert_spec.rb
@@ -3,23 +3,23 @@ require 'spec_helper'
 describe Riddle::Query::Insert do
   it 'handles inserts' do
     query = Riddle::Query::Insert.new('foo_core', [:id, :deleted], [4, false])
-    query.to_sql.should == 'INSERT INTO foo_core (id, deleted) VALUES (4, 0)'
+    query.to_sql.should == 'INSERT INTO foo_core (`id`, `deleted`) VALUES (4, 0)'
   end
   
   it 'handles replaces' do
     query = Riddle::Query::Insert.new('foo_core', [:id, :deleted], [4, false])
     query.replace!
-    query.to_sql.should == 'REPLACE INTO foo_core (id, deleted) VALUES (4, 0)'
+    query.to_sql.should == 'REPLACE INTO foo_core (`id`, `deleted`) VALUES (4, 0)'
   end
   
   it 'encloses strings in single quotes' do
     query = Riddle::Query::Insert.new('foo_core', [:id, :name], [4, 'bar'])
-    query.to_sql.should == "INSERT INTO foo_core (id, name) VALUES (4, 'bar')"
+    query.to_sql.should == "INSERT INTO foo_core (`id`, `name`) VALUES (4, 'bar')"
   end
   
   it 'handles inserts with more than one set of values' do
     query = Riddle::Query::Insert.new 'foo_core', [:id, :name], [[4, 'bar'], [5, 'baz']]
     query.to_sql.
-      should == "INSERT INTO foo_core (id, name) VALUES (4, 'bar'), (5, 'baz')"
+      should == "INSERT INTO foo_core (`id`, `name`) VALUES (4, 'bar'), (5, 'baz')"
   end
 end

--- a/spec/riddle/query/select_spec.rb
+++ b/spec/riddle/query/select_spec.rb
@@ -34,69 +34,69 @@ describe Riddle::Query::Select do
 
   it 'handles filters with integers' do
     query.from('foo_core').matching('foo').where(:bar_id => 10).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar_id = 10"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar_id` = 10"
   end
 
   it "handles exclusive filters with integers" do
     query.from('foo_core').matching('foo').where_not(:bar_id => 10).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar_id <> 10"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar_id` <> 10"
   end
 
   it "handles filters with true" do
     query.from('foo_core').matching('foo').where(:bar => true).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar = 1"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar` = 1"
   end
 
   it "handles exclusive filters with true" do
     query.from('foo_core').matching('foo').where_not(:bar => true).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar <> 1"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar` <> 1"
   end
 
   it "handles filters with false" do
     query.from('foo_core').matching('foo').where(:bar => false).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar = 0"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar` = 0"
   end
 
   it "handles exclusive filters with false" do
     query.from('foo_core').matching('foo').where_not(:bar => false).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar <> 0"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar` <> 0"
   end
 
   it "handles filters with arrays" do
     query.from('foo_core').matching('foo').where(:bars => [1, 2]).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bars IN (1, 2)"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bars` IN (1, 2)"
   end
 
   it "handles exclusive filters with arrays" do
     query.from('foo_core').matching('foo').where_not(:bars => [1, 2]).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bars NOT IN (1, 2)"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bars` NOT IN (1, 2)"
   end
 
   it "handles filters with timestamps" do
     time = Time.now
     query.from('foo_core').matching('foo').where(:created_at => time).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND created_at = #{time.to_i}"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `created_at` = #{time.to_i}"
   end
 
   it "handles exclusive filters with timestamps" do
     time = Time.now
     query.from('foo_core').matching('foo').where_not(:created_at => time).
-      to_sql.should == "SELECT * FROM foo_core WHERE MATCH('foo') AND created_at <> #{time.to_i}"
+      to_sql.should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `created_at` <> #{time.to_i}"
   end
 
   it "handles filters with ranges" do
     query.from('foo_core').matching('foo').where(:bar => 1..5).to_sql.
-      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND bar BETWEEN 1 AND 5"
+      should == "SELECT * FROM foo_core WHERE MATCH('foo') AND `bar` BETWEEN 1 AND 5"
   end
 
   it "handles filters expecting matches on all values" do
     query.from('foo_core').where_all(:bars => [1, 2]).to_sql.
-      should == "SELECT * FROM foo_core WHERE bars = 1 AND bars = 2"
+      should == "SELECT * FROM foo_core WHERE `bars` = 1 AND `bars` = 2"
   end
 
   it "handles exclusive filters expecting matches on none of the values" do
     query.from('foo_core').where_not_all(:bars => [1, 2]).to_sql.
-      should == "SELECT * FROM foo_core WHERE (bars <> 1 OR bars <> 2)"
+      should == "SELECT * FROM foo_core WHERE (`bars` <> 1 OR `bars` <> 2)"
   end
 
   it 'handles grouping' do


### PR DESCRIPTION
There are several reserved keywords in SphinxQL, such as status, which
will result in a syntax error if not escaped.  By surrounding them in
backticks reserved keywords can be used as column names.
