### PR TITLE
Escape order by and group by columns

### DIFF
--- a/lib/riddle/query/select.rb
+++ b/lib/riddle/query/select.rb
@@ -83,11 +83,11 @@ class Riddle::Query::Select
   def to_sql
     sql = "SELECT #{ @values.join(', ') } FROM #{ @indices.join(', ') }"
     sql << " WHERE #{ combined_wheres }" if wheres?
-    sql << " GROUP BY #{@group_by}"      if !@group_by.nil?
+    sql << " GROUP BY #{escape_column(@group_by)}"      if !@group_by.nil?
     unless @order_within_group_by.nil?
-      sql << " WITHIN GROUP ORDER BY #{@order_within_group_by}"
+      sql << " WITHIN GROUP ORDER BY #{escape_column(@order_within_group_by)}"
     end
-    sql << " ORDER BY #{@order_by}"      if !@order_by.nil?
+    sql << " ORDER BY #{escape_column(@order_by)}"      if !@order_by.nil?
     sql << " #{limit_clause}"   unless @limit.nil? && @offset.nil?
     sql << " #{options_clause}" unless @options.empty?
 
@@ -190,6 +190,11 @@ class Riddle::Query::Select
   end
 
   def escape_column(column)
-    "`#{column}`"
+    if column.to_s =~ /\A[`@]/
+      column
+    else
+      column_name, *extra = column.to_s.split(' ')
+      extra.unshift("`#{column_name}`").compact.join(' ')
+    end
   end
 end

--- a/spec/riddle/query/select_spec.rb
+++ b/spec/riddle/query/select_spec.rb
@@ -101,17 +101,32 @@ describe Riddle::Query::Select do
 
   it 'handles grouping' do
     query.from('foo_core').group_by('bar_id').to_sql.
-      should == "SELECT * FROM foo_core GROUP BY bar_id"
+      should == "SELECT * FROM foo_core GROUP BY `bar_id`"
   end
 
   it 'handles ordering' do
     query.from('foo_core').order_by('bar_id ASC').to_sql.
-      should == 'SELECT * FROM foo_core ORDER BY bar_id ASC'
+      should == 'SELECT * FROM foo_core ORDER BY `bar_id` ASC'
+  end
+
+  it 'handles ordering when an already escaped column is passed in' do
+    query.from('foo_core').order_by('`bar_id` ASC').to_sql.
+      should == 'SELECT * FROM foo_core ORDER BY `bar_id` ASC'
+  end
+
+  it 'handles ordering when just a symbol is passed in' do
+    query.from('foo_core').order_by(:bar_id).to_sql.
+      should == 'SELECT * FROM foo_core ORDER BY `bar_id`'
+  end
+
+  it 'handles ordering when a computed sphinx variable is passed in' do
+    query.from('foo_core').order_by('@weight DESC').to_sql.
+      should == 'SELECT * FROM foo_core ORDER BY @weight DESC'
   end
 
   it 'handles group ordering' do
     query.from('foo_core').order_within_group_by('bar_id ASC').to_sql.
-      should == 'SELECT * FROM foo_core WITHIN GROUP ORDER BY bar_id ASC'
+      should == 'SELECT * FROM foo_core WITHIN GROUP ORDER BY `bar_id` ASC'
   end
 
   it 'handles a limit' do


### PR DESCRIPTION
Special column names, like status, can also cause SphinxQL to raise an
error if not escaped with backticks.  All columns are now escaped,
except those that are sphinx expressions, e.g. @weight.  In order to
handle escaping order_by columns, which can come in with a direction
such as "created_at DESC", the column had to be split on spaces and only
the first part escaped.
