### PR TITLE
update gemspec metadata

### DIFF
--- a/riddle.gemspec
+++ b/riddle.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Pat Allan']
   s.email       = ['pat@freelancing-gods.com']
-  s.homepage    = 'http://pat.github.com/riddle/'
+  s.homepage    = 'http://pat.github.io/riddle/'
   s.summary     = %q{An API for Sphinx, written in and for Ruby.}
   s.description = %q{A Ruby API and configuration helper for the Sphinx search service.}
   s.license     = 'MIT'


### PR DESCRIPTION
This pull request updates some information in riddle's gemspec.

The first commit adds the license metadata. This helps automated tools such as rubygems.org or gem2rpm to find the license.

The second commit updates the URL to the new "github.io" scheme that github is using. (https://github.com/blog/1452-new-github-pages-domain-github-io)
