### PR TITLE
Add a common_sphinx_configuration setting.

### DIFF
--- a/lib/riddle/configuration/common.rb
+++ b/lib/riddle/configuration/common.rb
@@ -9,9 +9,10 @@ module Riddle
         ]
       end
 
-      attr_accessor *self.settings
+      attr_accessor :common_sphinx_configuration, *settings
 
       def render
+        return unless common_sphinx_configuration
         raise ConfigurationError unless valid?
 
         (

--- a/lib/riddle/configuration/indexer.rb
+++ b/lib/riddle/configuration/indexer.rb
@@ -6,10 +6,18 @@ module Riddle
           :mem_limit, :max_iops, :max_iosize, :max_xmlpipe2_field,
           :write_buffer, :max_file_field_buffer, :on_file_field_error,
           :lemmatizer_cache
+        ] + shared_settings
+      end
+
+      def self.shared_settings
+        [
+          :json_autoconv_numbers, :json_autoconv_keynames,
+          :on_json_attr_error, :rlp_root, :rlp_environment,
+          :rlp_max_batch_size, :rlp_max_batch_docs
         ]
       end
 
-      attr_accessor *self.settings
+      attr_accessor :common_sphinx_configuration, *settings
 
       def render
         raise ConfigurationError unless valid?
@@ -19,6 +27,15 @@ module Riddle
           settings_body +
           ["}", ""]
         ).join("\n")
+      end
+
+
+      private
+
+      def settings
+        settings = self.class.settings
+        settings -= self.class.shared_settings if common_sphinx_configuration
+        settings
       end
     end
   end

--- a/lib/riddle/configuration/section.rb
+++ b/lib/riddle/configuration/section.rb
@@ -12,7 +12,7 @@ module Riddle
       private
       
       def settings_body
-        self.class.settings.select { |setting|
+        settings.select { |setting|
           !send(setting).nil?
         }.collect { |setting|
           if send(setting) == ""
@@ -49,6 +49,10 @@ module Riddle
         end
         
         output
+      end
+
+      def settings
+        self.class.settings
       end
     end
   end

--- a/spec/unit/configuration/common_spec.rb
+++ b/spec/unit/configuration/common_spec.rb
@@ -17,21 +17,43 @@ describe Riddle::Configuration::Common do
       common.should respond_to("#{setting}=".to_sym)
     end
   end
-  
+
   it "should render a correct configuration" do
     common = Riddle::Configuration::Common.new
-    
+    common.common_sphinx_configuration = true
+
     common.render.should == <<-COMMON
 common
 {
 }
     COMMON
-    
+  
     common.lemmatizer_base = "/tmp"
     common.render.should == <<-COMMON
 common
 {
   lemmatizer_base = /tmp
+}
+    COMMON
+  end
+
+  it "should not be present when common_sphinx_configuration is not set" do
+    common = Riddle::Configuration::Common.new
+    common.render.should be_nil
+  end
+
+  it "should not be present when common_sphinx_configuration is false" do
+    common = Riddle::Configuration::Common.new
+    common.common_sphinx_configuration = false
+    common.render.should be_nil
+  end
+  
+  it "should render when common_sphinx_configuration is true" do
+    common = Riddle::Configuration::Common.new
+    common.common_sphinx_configuration = true
+    common.render.should == <<-COMMON
+common
+{
 }
     COMMON
   end

--- a/spec/unit/configuration/indexer_spec.rb
+++ b/spec/unit/configuration/indexer_spec.rb
@@ -33,4 +33,41 @@ indexer
 }
     INDEXER
   end
+
+  it "should render shared settings when common_sphinx_configuration is not set" do
+    indexer = Riddle::Configuration::Indexer.new
+    indexer.rlp_root = '/tmp'
+    
+    indexer.render.should == <<-INDEXER
+indexer
+{
+  rlp_root = /tmp
+}
+    INDEXER
+  end
+
+  it "should render shared settings when common_sphinx_configuration is false" do
+    indexer = Riddle::Configuration::Indexer.new
+    indexer.common_sphinx_configuration = false
+    indexer.rlp_root = '/tmp'
+
+    indexer.render.should == <<-INDEXER
+indexer
+{
+  rlp_root = /tmp
+}
+    INDEXER
+  end
+
+  it "should not render shared settings when common_sphinx_configuration is true" do
+    indexer = Riddle::Configuration::Indexer.new
+    indexer.common_sphinx_configuration = true
+    indexer.rlp_root = '/tmp'
+
+    indexer.render.should == <<-INDEXER
+indexer
+{
+}
+      INDEXER
+  end
 end


### PR DESCRIPTION
A new "common" configuration section was added in Sphinx 2.2.x containing several settings formally located in the "indexer" section. To maintain backwards compatibility with older versions of Sphinx, the new section will be disabled unless common_sphinx_configuration is set to true.
