### PR TITLE
fixes #84: allow group_by multiple fields

### DIFF
--- a/lib/riddle/query/select.rb
+++ b/lib/riddle/query/select.rb
@@ -100,7 +100,7 @@ class Riddle::Query::Select
   def to_sql
     sql = "SELECT #{ extended_values } FROM #{ @indices.join(', ') }"
     sql << " WHERE #{ combined_wheres }" if wheres?
-    sql << " #{group_prefix} #{escape_column(@group_by)}" if !@group_by.nil?
+    sql << " #{group_prefix} #{escape_columns(@group_by)}" if !@group_by.nil?
     unless @order_within_group_by.nil?
       sql << " WITHIN GROUP ORDER BY #{escape_columns(@order_within_group_by)}"
     end


### PR DESCRIPTION
Fixes #84: allow group_by multiple fields.

To recover grouped values:

```
search = MyClass.search :with => {:some_id => 85}, :group_by => "user_id, type";
search.context[:panes] << ThinkingSphinx::Panes::AttributesPane
search.each do |item|
  item.sphinx_attributes[‘count(*)’] # count
  item.sphinx_attributes[‘user_id’]
  item.sphinx_attributes[‘type’]
end
```
