### PR TITLE
Allow stop to fail

### DIFF
--- a/lib/riddle/controller.rb
+++ b/lib/riddle/controller.rb
@@ -63,8 +63,8 @@ module Riddle
       else
         `#{cmd}`
       end
-    ensure
-      return !running?
+
+      !running?
     end
 
     def pid


### PR DESCRIPTION
I've been bitten by this as well: https://github.com/pat/thinking-sphinx/issues/718 

The reason why stop is getting frozen is because of the `return` inside `ensure` clause. Such construct will stop exception propagation (in this case thrown by `check_for_configuration_file`). 

Since the code in hand doesn't need any specific exception handling I think `ensure` can be removed and just leave the `!running?` value to be returned. 
