### PR TITLE
Fix some spec failures

### DIFF
--- a/spec/functional/escaping_spec.rb
+++ b/spec/functional/escaping_spec.rb
@@ -14,7 +14,7 @@ describe 'SphinxQL escaping', :live => true do
     it "escapes #{string}" do
       lambda {
         connection.query sphinxql_matching(Riddle::Query.escape(string))
-      }.should_not raise_error(Mysql2::Error)
+      }.should_not raise_error
     end
   end
 

--- a/spec/riddle/auto_version_spec.rb
+++ b/spec/riddle/auto_version_spec.rb
@@ -4,7 +4,7 @@ describe Riddle::AutoVersion do
   describe '.configure' do
     before :each do
       @controller = Riddle::Controller.new stub('configuration'), 'sphinx.conf'
-      Riddle::Controller.stub!(:new => @controller)
+      Riddle::Controller.stub(:new => @controller)
 
       unless ENV['SPHINX_VERSION'].nil?
         @env_version, ENV['SPHINX_VERSION'] = ENV['SPHINX_VERSION'].dup, nil
@@ -18,77 +18,77 @@ describe Riddle::AutoVersion do
     it "should require 0.9.8 if that is the known version" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/0.9.8')
 
-      @controller.stub!(:sphinx_version => '0.9.8')
+      @controller.stub(:sphinx_version => '0.9.8')
       Riddle::AutoVersion.configure
     end
 
     it "should require 0.9.9 if that is the known version" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/0.9.9')
 
-      @controller.stub!(:sphinx_version => '0.9.9')
+      @controller.stub(:sphinx_version => '0.9.9')
       Riddle::AutoVersion.configure
     end
 
     it "should require 1.10 if that is the known version" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/1.10')
 
-      @controller.stub!(:sphinx_version => '1.10-beta')
+      @controller.stub(:sphinx_version => '1.10-beta')
       Riddle::AutoVersion.configure
     end
 
     it "should require 1.10 if using 1.10 with 64 bit IDs" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/1.10')
 
-      @controller.stub!(:sphinx_version => '1.10-id64-beta')
+      @controller.stub(:sphinx_version => '1.10-id64-beta')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.0.1 if that is the known version" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.0.1')
 
-      @controller.stub!(:sphinx_version => '2.0.1-beta')
+      @controller.stub(:sphinx_version => '2.0.1-beta')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.0.1 if 2.0.2-dev is being used" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.0.1')
 
-      @controller.stub!(:sphinx_version => '2.0.2-dev')
+      @controller.stub(:sphinx_version => '2.0.2-dev')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.1.0 if 2.0.3 is being used" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.1.0')
 
-      @controller.stub!(:sphinx_version => '2.0.3-release')
+      @controller.stub(:sphinx_version => '2.0.3-release')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.1.0 if 2.0.4 is being used" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.1.0')
 
-      @controller.stub!(:sphinx_version => '2.0.4-release')
+      @controller.stub(:sphinx_version => '2.0.4-release')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.1.0 if 2.0.5 is being used" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.1.0')
 
-      @controller.stub!(:sphinx_version => '2.0.5-release')
+      @controller.stub(:sphinx_version => '2.0.5-release')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.1.0 if 2.2.1 is being used" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.1.0')
 
-      @controller.stub!(:sphinx_version => '2.2.1-beta')
+      @controller.stub(:sphinx_version => '2.2.1-beta')
       Riddle::AutoVersion.configure
     end
 
     it "should require 2.1.0 if that is the known version" do
       Riddle::AutoVersion.should_receive(:require).with('riddle/2.1.0')
 
-      @controller.stub!(:sphinx_version => '2.1.0-dev')
+      @controller.stub(:sphinx_version => '2.1.0-dev')
       Riddle::AutoVersion.configure
     end
   end

--- a/spec/riddle/controller_spec.rb
+++ b/spec/riddle/controller_spec.rb
@@ -7,32 +7,32 @@ describe Riddle::Controller do
     end
     
     it "should return 1.10 if using 1.10-beta" do
-      @controller.stub!(:` => 'Sphinx 1.10-beta (r2420)')
+      @controller.stub(:` => 'Sphinx 1.10-beta (r2420)')
       @controller.sphinx_version.should == '1.10-beta'
     end
     
     it "should return 0.9.9 if using 0.9.9" do
-      @controller.stub!(:` => 'Sphinx 0.9.9-release (r2117)')
+      @controller.stub(:` => 'Sphinx 0.9.9-release (r2117)')
       @controller.sphinx_version.should == '0.9.9'
     end
     
     it "should return 0.9.9 if using 0.9.9 rc2" do
-      @controller.stub!(:` => 'Sphinx 0.9.9-rc2 (r1785)')
+      @controller.stub(:` => 'Sphinx 0.9.9-rc2 (r1785)')
       @controller.sphinx_version.should == '0.9.9'
     end
     
     it "should return 0.9.9 if using 0.9.9 rc1" do
-      @controller.stub!(:` => 'Sphinx 0.9.9-rc1 (r1566)')
+      @controller.stub(:` => 'Sphinx 0.9.9-rc1 (r1566)')
       @controller.sphinx_version.should == '0.9.9'
     end
     
     it "should return 0.9.8 if using 0.9.8.1" do
-      @controller.stub!(:` => 'Sphinx 0.9.8.1-release (r1533)')
+      @controller.stub(:` => 'Sphinx 0.9.8.1-release (r1533)')
       @controller.sphinx_version.should == '0.9.8'
     end
     
     it "should return 0.9.8 if using 0.9.8" do
-      @controller.stub!(:` => 'Sphinx 0.9.8-release (r1371)')
+      @controller.stub(:` => 'Sphinx 0.9.8-release (r1371)')
       @controller.sphinx_version.should == '0.9.8'
     end
   end


### PR DESCRIPTION
Fix spec errors leading to the following failures:
- <code>`expect { }.not_to raise_error(SpecificErrorClass)` is not valid, use `expect { }.not_to raise_error` (with no args) instead</code>
- <code>undefined method `stub!`</code>