### PR TITLE
Update escape_column to not escape JSON expressions using dot or bracket notation

### DIFF
--- a/lib/riddle/query/select.rb
+++ b/lib/riddle/query/select.rb
@@ -224,7 +224,7 @@ class Riddle::Query::Select
   end
 
   def escape_column(column)
-    if column.to_s[/\A[`@]/] || column.to_s[/\A\w+\(/]
+    if column.to_s[/\A[`@]/] || column.to_s[/\A\w+\(/] || column.to_s[/\A\w+[.\[]/]
       column
     else
       column_name, *extra = column.to_s.split(' ')

--- a/spec/riddle/query/select_spec.rb
+++ b/spec/riddle/query/select_spec.rb
@@ -24,6 +24,16 @@ describe Riddle::Query::Select do
       should == 'SELECT @weight FROM foo_core'
   end
 
+  it 'handles JSON as a select value using dot notation' do
+    query.values('key1.key2.key3').from('foo_core').to_sql.
+      should == 'SELECT key1.key2.key3 FROM foo_core'
+  end
+
+  it 'handles JSON as a select value using bracket notation 2' do
+    query.values("key1['key2']['key3']").from('foo_core').to_sql.
+        should == "SELECT key1['key2']['key3'] FROM foo_core"
+  end
+
   it "can prepend select values" do
     query.values('@weight').prepend_values('foo').from('foo_core').to_sql.
       should == 'SELECT foo, @weight FROM foo_core'
@@ -125,6 +135,16 @@ describe Riddle::Query::Select do
   it "handles exclusive filters expecting matches on none of the values" do
     query.from('foo_core').where_not_all(:bars => [1, 2]).to_sql.
       should == "SELECT * FROM foo_core WHERE (`bars` <> 1 OR `bars` <> 2)"
+  end
+
+  it 'handles filters on JSON with dot syntax' do
+    query.from('foo_core').where('key1.key2.key3' => 10).to_sql.
+      should == "SELECT * FROM foo_core WHERE key1.key2.key3 = 10"
+  end
+
+  it 'handles filters on JSON with bracket syntax' do
+    query.from('foo_core').where("key1['key2']['key3']" => 10).to_sql.
+        should == "SELECT * FROM foo_core WHERE key1['key2']['key3'] = 10"
   end
 
   it 'handles grouping' do


### PR DESCRIPTION
As per [How to filter by Sphinx JSON attributes](http://sphinxsearch.com/blog/2013/08/08/full-json-support-in-trunk/), sphinx can search JSON structures through dot and bracket notation, but Riddle currently tries to escape those references. This PR is a bit naive (as it just skips escaping when the column name contains a `.` or `[`), but it should work. If there is a way to introspect column types from the name (I didn't find a way to do so), maybe this could be made a bit more intelligent.