### PR TITLE
Stop packaging test files with the gem

### DIFF
--- a/riddle.gemspec
+++ b/riddle.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'riddle'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rake',   '>= 0.9.2'


### PR DESCRIPTION
It drastically reduces the size of the gem, from 1.9M to 32K. The default for new gems (created by bundler) is not to include test files. See bundler/bundler#3207