### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 - 2.5.8
 - 2.6.6
 - 2.7.1
-- jruby-9.2.9.0
+- jruby-9.2.11.1
 env:
   matrix:
   - SPHINX_VERSION=2.1.9 SPHINX_ENGINE=sphinx


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)